### PR TITLE
CapistranoのRailsプラグインの動作確認

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -6,8 +6,8 @@ require "capistrano/deploy"
 
 require "capistrano/rbenv"
 require "capistrano/bundler"
-# require "capistrano/rails/assets"
-# require "capistrano/rails/migrations"
+require "capistrano/rails/assets"
+require "capistrano/rails/migrations"
 
 # Load the SCM plugin appropriate to your project:
 #

--- a/Capfile
+++ b/Capfile
@@ -5,7 +5,7 @@ require "capistrano/setup"
 require "capistrano/deploy"
 
 require "capistrano/rbenv"
-# require "capistrano/bundler"
+require "capistrano/bundler"
 # require "capistrano/rails/assets"
 # require "capistrano/rails/migrations"
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,9 +24,9 @@ development:
 test:
   <<: *default
   # database: db/test.sqlite3
-  username: <%= ENV.fetch("PGUSER") %>
-  password: <%= ENV.fetch("PGPASSWORD") %>
-  host: <%= ENV.fetch("PGHOST") %>
+  username: <%= ENV.fetch("PGUSER", "_") %>
+  password: <%= ENV.fetch("PGPASSWORD", "_") %>
+  host: <%= ENV.fetch("PGHOST", "_") %>
   database: circle_test
 
 production:

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,3 +45,7 @@ set :rbenv_type, :user
 set :rbenv_ruby, File.read('.ruby-version').strip
 set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
 set :rbenv_map_bins, %w{rake gem bundle ruby rails}
+
+# bundlerの設定
+set :linked_dirs, fetch(:linked_dirs, []) << '.bundle'
+set :bundle_jobs, 1 #デフォルトでは4になっている。ec2インスタンスのCPUコア数に合わる。


### PR DESCRIPTION
databaseのconfigに記載されていた環境変数をCapistranoが認識しないため、デフォルト値を与えた。