### PR TITLE
ISOの登録にバリデーションを追加した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /myapp
 COPY Gemfile /myapp/Gemfile
 COPY Gemfile.lock /myapp/Gemfile.lock
 
+RUN gem install bundler -v 2.1.4
 RUN bundle install
 
 COPY . /myapp

--- a/app/controllers/films_controller.rb
+++ b/app/controllers/films_controller.rb
@@ -59,7 +59,7 @@ class FilmsController < ApplicationController
 
     send_data(File.read(filepath), filename: "#{params[:id].to_s}.csv")
 
-    File.delete(filepath)
+    File.delete(filepath) if File.file?(filepath)
   end
 
   private

--- a/app/models/film.rb
+++ b/app/models/film.rb
@@ -3,6 +3,8 @@ class Film < ApplicationRecord
   has_many :photos, dependent: :destroy #ユーザには複数のphotosがいる,filmの削除でphotoも消去
   default_scope -> { order(created_at: :desc) } #作成日時を降順(新しいものが上)で並べる
   validates :name, presence: true, length: { maximum: 127 }
-  validates :iso, presence: true
+
+  VALID_ISO_REGEX = /\A\d+\z/
+  validates :iso, presence: true, format: {with: VALID_ISO_REGEX}
   validates :user_id, presence: true
 end

--- a/test/integration/film_export_test.rb
+++ b/test/integration/film_export_test.rb
@@ -4,24 +4,25 @@ class FilmExportTest < ActionDispatch::IntegrationTest
   def setup
     @user = users(:user1)
     @film = films(:film1)
+    @film2 = films(:film2)
   end
 
-  def request_film_export
+  def request_film_export(film)
     post film_export_path, params: {
-      id: @film.id
+      id: film.id
     }
   end
 
   test "撮影データをCSVファイルでダウンロードできるか" do
     log_in_as(@user)
-    request_film_export
+    request_film_export(@film)
     assert_match "text/csv", response.headers["Content-Type"]
     assert_match /attachment/, response.headers["Content-Disposition"]
   end
 
   test "撮影データのCSVファイルの内容が正しいか" do
     log_in_as(@user)
-    request_film_export
+    request_film_export(@film2)
     response.body.each_line.each_with_index do |line, idx|
       if idx == 0 
         assert_match "id,シャッタースピード,F値,撮影日", line

--- a/test/models/film_test.rb
+++ b/test/models/film_test.rb
@@ -20,8 +20,13 @@ class FilmTest < ActiveSupport::TestCase
     assert_not @film.valid?
   end
 
-  test "空白のisomに対するバリデーションが機能するかテスト" do
+  test "空白のisoに対するバリデーションが機能するかテスト" do
     @film.iso = "      "
+    assert_not @film.valid?
+  end
+
+  test "数字以外のisoに対してバリデーションが機能するかテスト" do
+    @film.iso = "a"
     assert_not @film.valid?
   end
 


### PR DESCRIPTION
ISOに数字のみを登録できるようにした。
ファイル出力にて、一時ファイルを消す際に、ファイルの存在判定を行うように変更した。